### PR TITLE
Feature/#3 schedule main

### DIFF
--- a/src/components/main/Main.tsx
+++ b/src/components/main/Main.tsx
@@ -1,13 +1,17 @@
 import React from "react";
-import Search from "./Search";
 import { View } from "react-native";
+
+/* 페이지 import */
+import Search from "./Search";
 import Tags from "./Tags";
+import Schedules from "./Schedules";
 
 function Main() {
   return (
     <View>
       <Search />
       <Tags />
+      <Schedules />
     </View>
   );
 }

--- a/src/components/main/Main.tsx
+++ b/src/components/main/Main.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { View } from "react-native";
 
 /* 페이지 import */

--- a/src/components/main/Schedule.tsx
+++ b/src/components/main/Schedule.tsx
@@ -5,9 +5,17 @@ type ScheduleType = {
   id: number;
   name: string;
   description: string;
+  date_start: string;
+  date_end: string;
 };
 
-function Schedule({ id, name, description }: ScheduleType) {
+function Schedule({
+  id,
+  name,
+  description,
+  date_start,
+  date_end,
+}: ScheduleType) {
   return (
     <TouchableOpacity
       style={styles.scheduleContainer}
@@ -20,13 +28,22 @@ function Schedule({ id, name, description }: ScheduleType) {
         }}
       >
         <Text
-          style={{ ...styles.scheduleText, fontSize: 20, fontWeight: "700" }}
+          // style={{ ...styles.scheduleText, fontSize: 20, fontWeight: "700" }}
+          style={[styles.scheduleText, styles.name]}
         >
           {name}
         </Text>
-        <Text style={{ ...styles.scheduleText, fontSize: 10 }}>
+        <Text
+          style={[styles.scheduleText, styles.description]}
+          numberOfLines={1}
+          ellipsizeMode="tail"
+        >
           {description}
         </Text>
+      </View>
+      <View style={{ marginVertical: 10, position: "absolute", right: 10 }}>
+        <Text style={styles.date}>{date_start}</Text>
+        <Text style={styles.date}>{date_end}</Text>
       </View>
     </TouchableOpacity>
   );
@@ -52,5 +69,18 @@ const styles = StyleSheet.create({
     marginHorizontal: 10,
     alignItems: "center",
     lineHeight: 50,
+  },
+  name: {
+    width: 90,
+    fontSize: 20,
+    fontWeight: "700",
+  },
+  description: {
+    fontSize: 10,
+    width: 115,
+  },
+  date: {
+    fontSize: 10,
+    lineHeight: 15,
   },
 });

--- a/src/components/main/Schedule.tsx
+++ b/src/components/main/Schedule.tsx
@@ -1,0 +1,56 @@
+import { View, Text, TouchableOpacity } from "react-native";
+import { StyleSheet } from "react-native";
+
+type ScheduleType = {
+  id: number;
+  name: string;
+  description: string;
+};
+
+function Schedule({ id, name, description }: ScheduleType) {
+  return (
+    <TouchableOpacity
+      style={styles.scheduleContainer}
+      onPress={() => console.log(`Schedule ${id} button Pressed!`)}
+    >
+      <View style={styles.leftBar} />
+      <View
+        style={{
+          flexDirection: "row",
+        }}
+      >
+        <Text
+          style={{ ...styles.scheduleText, fontSize: 20, fontWeight: "700" }}
+        >
+          {name}
+        </Text>
+        <Text style={{ ...styles.scheduleText, fontSize: 10 }}>
+          {description}
+        </Text>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+export default Schedule;
+
+const styles = StyleSheet.create({
+  scheduleContainer: {
+    flexDirection: "row",
+    marginTop: 5,
+    marginHorizontal: 3,
+    borderRadius: 10,
+  },
+  leftBar: {
+    backgroundColor: "yellowgreen",
+    width: 5,
+    height: 50,
+    borderRadius: 10,
+  },
+  scheduleText: {
+    height: 50,
+    marginHorizontal: 10,
+    alignItems: "center",
+    lineHeight: 50,
+  },
+});

--- a/src/components/main/Schedule.tsx
+++ b/src/components/main/Schedule.tsx
@@ -9,30 +9,20 @@ type ScheduleType = {
   date_end: string;
 };
 
-function Schedule({
-  id,
-  name,
-  description,
-  date_start,
-  date_end,
-}: ScheduleType) {
+function Schedule({ name, description, date_start, date_end }: ScheduleType) {
   return (
-    <TouchableOpacity
-      style={styles.scheduleContainer}
-      onPress={() => console.log(`Schedule ${id} button Pressed!`)}
-    >
+    <TouchableOpacity style={styles.container}>
+      {/* 좌측 바 */}
       <View style={styles.leftBar} />
       <View
         style={{
           flexDirection: "row",
         }}
       >
-        <Text
-          // style={{ ...styles.scheduleText, fontSize: 20, fontWeight: "700" }}
-          style={[styles.scheduleText, styles.name]}
-        >
-          {name}
-        </Text>
+        {/* 일정 이름 */}
+        <Text style={[styles.scheduleText, styles.name]}>{name}</Text>
+
+        {/* 일정 설명 */}
         <Text
           style={[styles.scheduleText, styles.description]}
           numberOfLines={1}
@@ -42,7 +32,9 @@ function Schedule({
         </Text>
       </View>
       <View style={{ marginVertical: 10, position: "absolute", right: 10 }}>
+        {/* 일정 시작 시각 */}
         <Text style={styles.date}>{date_start}</Text>
+        {/* 일정 종료 시각 */}
         <Text style={styles.date}>{date_end}</Text>
       </View>
     </TouchableOpacity>
@@ -52,33 +44,39 @@ function Schedule({
 export default Schedule;
 
 const styles = StyleSheet.create({
-  scheduleContainer: {
+  /* 컨테이너 스타일 */
+  container: {
     flexDirection: "row",
     marginTop: 5,
     marginHorizontal: 3,
     borderRadius: 10,
   },
+  /* 좌측 바 스타일 */
   leftBar: {
     backgroundColor: "yellowgreen",
     width: 5,
     height: 50,
     borderRadius: 10,
   },
+  /* 이름, 설명, 시각 공통 스타일 */
   scheduleText: {
     height: 50,
     marginHorizontal: 10,
     alignItems: "center",
     lineHeight: 50,
   },
+  /* 일정 이름 스타일 */
   name: {
     width: 90,
     fontSize: 20,
     fontWeight: "700",
   },
+  /* 일정 설명 스타일 */
   description: {
     fontSize: 10,
     width: 115,
   },
+  /* 일정 시각 스타일 */
   date: {
     fontSize: 10,
     lineHeight: 15,

--- a/src/components/main/Schedules.tsx
+++ b/src/components/main/Schedules.tsx
@@ -15,6 +15,7 @@ type ScheduleType = {
 };
 
 function Schedules() {
+  /* 임시 데이터 */
   const schedules = [
     {
       id: 1,
@@ -39,6 +40,7 @@ function Schedules() {
     },
   ];
 
+  /* 가장 가까운 여행 일정(2개) 저장 */
   const [nearSchedule, setNearSchedule] = useState<Array<ScheduleType>>([]);
 
   const showNearSchedule = () => {
@@ -47,11 +49,13 @@ function Schedules() {
     setNearSchedule(nearSchedule);
   };
 
+  /* 날짜 형식 변환 */
   const formatDate = (date: Date) => {
     const year = date.getFullYear();
     const month = date.getMonth();
     const day = date.getDate();
     const hour = date.getHours();
+    /* minute이 0일 경우 00으로 변환 */
     const minute = date.getMinutes() === 0 ? "00" : date.getMinutes();
 
     return `${year}. ${month}. ${day} ${hour}:${minute}`;
@@ -78,7 +82,6 @@ function Schedules() {
           size={20}
           color="white"
           style={{ lineHeight: 50, position: "absolute", right: 10 }}
-          onPress={() => console.log("Schedules Button Pressed!")}
         />
       </View>
       {nearSchedule.map((schedule) => (
@@ -98,10 +101,12 @@ function Schedules() {
 export default Schedules;
 
 const styles = StyleSheet.create({
+  /* 컨테이너 스타일 */
   container: {
     marginTop: 60,
     marginHorizontal: 15,
   },
+  /* 제목 스타일 */
   title: {
     height: 35,
     borderRadius: 10,

--- a/src/components/main/Schedules.tsx
+++ b/src/components/main/Schedules.tsx
@@ -1,0 +1,103 @@
+import { View, Text, StyleSheet } from "react-native";
+
+/* vector-icons */
+import { FontAwesome, MaterialIcons } from "@expo/vector-icons";
+
+import Schedule from "./Schedule";
+import { useState, useEffect } from "react";
+
+type Schedule = {
+  id: number;
+  name: string;
+  description: string;
+  date_start: Date;
+  date_end: Date;
+};
+
+function Schedules() {
+  const schedules = [
+    {
+      id: 1,
+      name: "플랜 이름 1",
+      description: "서울에서 하는 조선시대 역사 체험",
+      date_start: new Date("2024-02-19T10:00:00"),
+      date_end: new Date("2024-02-19T19:00:00"),
+    },
+    {
+      id: 2,
+      name: "플랜 이름 3",
+      description: "부산 맛집 탐방",
+      date_start: new Date("2024-02-21T10:00:00"),
+      date_end: new Date("2024-02-21T19:00:00"),
+    },
+    {
+      id: 3,
+      name: "플랜 이름 2",
+      description: "대구 동성로 맛집 탐방",
+      date_start: new Date("2024-02-20T10:00:00"),
+      date_end: new Date("2024-02-20T19:00:00"),
+    },
+  ];
+
+  const [nearSchedule, setNearSchedule] = useState<Array<Schedule>>([]);
+
+  const showNearSchedule = () => {
+    schedules.sort((a, b) => a.date_start.getTime() - b.date_start.getTime());
+    const nearSchedule = schedules.slice(0, 2);
+    setNearSchedule(nearSchedule);
+  };
+
+  useEffect(() => {
+    showNearSchedule();
+  }, []);
+
+  console.log(schedules);
+  console.log(nearSchedule);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.title}>
+        <FontAwesome
+          name="circle"
+          size={20}
+          color="red"
+          style={{ marginLeft: 10 }}
+        />
+        <Text style={{ color: "white", marginLeft: 10, fontWeight: "700" }}>
+          여행 일정
+        </Text>
+        <MaterialIcons
+          name="arrow-forward-ios"
+          size={20}
+          color="white"
+          style={{ lineHeight: 50, position: "absolute", right: 10 }}
+          onPress={() => console.log("Schedules Button Pressed!")}
+        />
+      </View>
+      {nearSchedule.map((schedule) => (
+        <Schedule
+          key={schedule.id}
+          id={schedule.id}
+          name={schedule.name}
+          description={schedule.description}
+        />
+      ))}
+    </View>
+  );
+}
+
+export default Schedules;
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 60,
+    marginHorizontal: 15,
+  },
+  title: {
+    height: 35,
+    borderRadius: 10,
+    backgroundColor: "black",
+    alignItems: "center",
+    flexDirection: "row",
+  },
+});

--- a/src/components/main/Schedules.tsx
+++ b/src/components/main/Schedules.tsx
@@ -6,7 +6,7 @@ import { FontAwesome, MaterialIcons } from "@expo/vector-icons";
 import Schedule from "./Schedule";
 import { useState, useEffect } from "react";
 
-type Schedule = {
+type ScheduleType = {
   id: number;
   name: string;
   description: string;
@@ -39,7 +39,7 @@ function Schedules() {
     },
   ];
 
-  const [nearSchedule, setNearSchedule] = useState<Array<Schedule>>([]);
+  const [nearSchedule, setNearSchedule] = useState<Array<ScheduleType>>([]);
 
   const showNearSchedule = () => {
     schedules.sort((a, b) => a.date_start.getTime() - b.date_start.getTime());
@@ -47,12 +47,19 @@ function Schedules() {
     setNearSchedule(nearSchedule);
   };
 
+  const formatDate = (date: Date) => {
+    const year = date.getFullYear();
+    const month = date.getMonth();
+    const day = date.getDate();
+    const hour = date.getHours();
+    const minute = date.getMinutes() === 0 ? "00" : date.getMinutes();
+
+    return `${year}. ${month}. ${day} ${hour}:${minute}`;
+  };
+
   useEffect(() => {
     showNearSchedule();
   }, []);
-
-  console.log(schedules);
-  console.log(nearSchedule);
 
   return (
     <View style={styles.container}>
@@ -80,6 +87,8 @@ function Schedules() {
           id={schedule.id}
           name={schedule.name}
           description={schedule.description}
+          date_start={formatDate(schedule.date_start)}
+          date_end={formatDate(schedule.date_end)}
         />
       ))}
     </View>

--- a/src/components/main/Schedules.tsx
+++ b/src/components/main/Schedules.tsx
@@ -5,6 +5,11 @@ import { FontAwesome, MaterialIcons } from "@expo/vector-icons";
 
 import Schedule from "./Schedule";
 import { useState, useEffect } from "react";
+import { useNavigation } from "@react-navigation/native";
+import {
+  MyNavigationProp,
+  RootStackParamList,
+} from "../../navigation/NavigationProps";
 
 type ScheduleType = {
   id: number;
@@ -61,6 +66,10 @@ function Schedules() {
     return `${year}. ${month}. ${day} ${hour}:${minute}`;
   };
 
+  /* navigation 추가 */
+  const navigation =
+    useNavigation<MyNavigationProp<keyof RootStackParamList>>();
+
   useEffect(() => {
     showNearSchedule();
   }, []);
@@ -82,6 +91,7 @@ function Schedules() {
           size={20}
           color="white"
           style={{ lineHeight: 50, position: "absolute", right: 10 }}
+          onPress={() => navigation.navigate("여행 일정")}
         />
       </View>
       {nearSchedule.map((schedule) => (

--- a/src/components/main/Search.tsx
+++ b/src/components/main/Search.tsx
@@ -73,7 +73,7 @@ function Search() {
           style={{ margin: 13 }}
         />
         <TextInput
-          placeholder="어디로 갈까"
+          placeholder="관광지 이름, 지역 이름을 검색해 보세요"
           style={{ margin: 5 }}
           value={searchText}
           onChangeText={(text) => setSearchText(text)}
@@ -141,6 +141,9 @@ const styles = StyleSheet.create({
     borderColor: "#DC2626",
     borderRadius: 20,
     backgroundColor: "white",
+    position: "absolute",
+    top: 100,
+    zIndex: 1,
   },
   /* 각 검색 결과 스타일 */
   result: {

--- a/src/components/main/Tags.tsx
+++ b/src/components/main/Tags.tsx
@@ -1,5 +1,5 @@
 import { useNavigation } from "@react-navigation/native";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import {
   StyleSheet,
   View,
@@ -8,6 +8,7 @@ import {
   ScrollView,
   Pressable,
 } from "react-native";
+
 import {
   MyNavigationProp,
   RootStackParamList,
@@ -32,11 +33,13 @@ function Tags() {
     { id: "7", tagName: "#프로그래밍" },
   ];
 
-  const [visibleTags, setVisibleTags] = useState<Tag[]>([
+  /* 전체 태그 상태 관리 */
+  const [allTags, setAllTags] = useState<Tag[]>([
     ...tags,
     { id: "more", tagName: "..." },
   ]);
 
+  /* navigation 추가 */
   const navigation =
     useNavigation<MyNavigationProp<keyof RootStackParamList>>();
 
@@ -44,14 +47,14 @@ function Tags() {
     <ScrollView
       horizontal={true}
       showsHorizontalScrollIndicator={false}
-      style={styles.tagsContainer}
+      style={styles.container}
     >
-      {visibleTags.map((tag, index) => (
+      {allTags.map((tag, index) => (
         <Pressable
           key={tag.id}
           style={styles.tag}
           onPress={() => {
-            if (index === visibleTags.length - 1) {
+            if (index === allTags.length - 1) {
               navigation.navigate("태그 편집");
             }
           }}
@@ -64,7 +67,8 @@ function Tags() {
 }
 
 const styles = StyleSheet.create({
-  tagsContainer: {
+  /* 태그 컨테이너 스타일 */
+  container: {
     flexDirection: "row",
     width: screenWidth - 20,
     height: 100,
@@ -74,6 +78,7 @@ const styles = StyleSheet.create({
     top: 100,
     zIndex: -1,
   },
+  /* 각 태그 스타일 */
   tag: {
     borderColor: "#DC2626",
     borderWidth: 1,

--- a/src/components/profile/Schedules.tsx
+++ b/src/components/profile/Schedules.tsx
@@ -1,0 +1,11 @@
+import { View, Text } from "react-native";
+
+function Schedules() {
+  return (
+    <View style={{ alignItems: "center", justifyContent: "center" }}>
+      <Text>All Schedules Page</Text>
+    </View>
+  );
+}
+
+export default Schedules;

--- a/src/navigation/Navigation.tsx
+++ b/src/navigation/Navigation.tsx
@@ -13,6 +13,7 @@ import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { Entypo, FontAwesome, FontAwesome6 } from "@expo/vector-icons";
 import { createStackNavigator } from "@react-navigation/stack";
 import TagEdit from "../components/profile/TagEdit";
+import Schedules from "../components/profile/Schedules";
 
 /* 하단 내비게이션 바 생성 */
 const Tab = createBottomTabNavigator();
@@ -49,6 +50,7 @@ export default function Navigation() {
                 options={{ headerShown: false }}
               />
               <Stack.Screen name="태그 편집" component={TagEdit} />
+              <Stack.Screen name="여행 일정" component={Schedules} />
             </Stack.Navigator>
           )}
         </Tab.Screen>

--- a/src/navigation/NavigationProps.tsx
+++ b/src/navigation/NavigationProps.tsx
@@ -4,6 +4,7 @@ export type RootStackParamList = {
   Home: undefined;
   Test: undefined;
   "태그 편집": undefined;
+  "여행 일정": undefined;
 };
 
 export type MyNavigationProp<T extends keyof RootStackParamList> =


### PR DESCRIPTION
## #️⃣연관된 이슈

#3 

## 📝작업 내용

> 여행 일정 UI 구현(일정 이름, 설명, 시작 시각, 종료 시각)
> 가장 가까운 일정 2개만 렌더링되도록 구현
> 여행 일정 페이지(임시 페이지) 라우팅

### 스크린샷
- UI(상단 바 화살표 누를 시 여행 일정 페이지 라우팅)
![image](https://github.com/THE-FIRST-DANCE/soomga-app/assets/126875714/2f633f84-93f7-4e99-95f3-66d47b3f1fac)

## 💬리뷰 요구사항(선택)
> 검색창 placeholder도 함께 변경함
> 일정 데이터 백엔드와 연결 필요